### PR TITLE
Explicitly call python3 because `str` is using python3 features

### DIFF
--- a/quicktest.sh
+++ b/quicktest.sh
@@ -1,4 +1,4 @@
 rm -rf build && mkdir build \
     && cd build && cmake .. \
     && make -j && ./kalman_test && cd .. \
-    && python ./examples/Robot1/visualization.py --path_to_exec build --makeplot
+    && python3 ./examples/Robot1/visualization.py --path_to_exec build --makeplot


### PR DESCRIPTION
This is a bug fix.

When I run `quicktest.sh`, the code `line_string = str(line.splitlines()[0], "utf-8")` produces below error:

```
...
[----------] Global test environment tear-down
[==========] 20 tests from 8 test cases ran. (1 ms total)
[  PASSED  ] 20 tests.
Traceback (most recent call last):
  File "./examples/Robot1/visualization.py", line 40, in <module>
    line_string = str(line.splitlines()[0], "utf-8")
TypeError: str() takes at most 1 argument (2 given)
```

This is due to the fact that I have both python 2 and 3 installed. `str` in python 2 only takes 1 argument. But python3 allows two more additional arguments (encoding and errors). Changing from `python` to `python3` fixes the error message.

Since the original repo is not being maintained, I'm here to add my fix to yours - the most actively maintained one. Thank you for maintaining it.